### PR TITLE
Option --skip-permission-denied

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 __pycache__/
 /dist
 /src/*.egg-info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+* 2026-03-17 Added option `--skip-permission-denied` for ignoring permission denied errors on folders when pulling files from Android - issue #8
+

--- a/src/BetterADBSync/FileSystems/Android.py
+++ b/src/BetterADBSync/FileSystems/Android.py
@@ -1,3 +1,4 @@
+import errno
 from typing import Iterable, Iterator, List, NoReturn, Tuple
 import logging
 import os
@@ -56,6 +57,7 @@ class AndroidFileSystem(FileSystem):
 
     RE_NO_SUCH_FILE = re.compile("^.*: No such file or directory$")
     RE_LS_NOT_A_DIRECTORY = re.compile("ls: .*: Not a directory$")
+    RE_PERMISSION_DENIED = re.compile("ls: (.*): Permission denied")
     RE_TOTAL = re.compile("^total \\d+$")
 
     RE_REALPATH_NO_SUCH_FILE = re.compile("^realpath: .*: No such file or directory$")
@@ -63,8 +65,8 @@ class AndroidFileSystem(FileSystem):
 
     ADBSYNC_END_OF_COMMAND = "ADBSYNC END OF COMMAND"
 
-    def __init__(self, adb_arguments: List[str], adb_encoding: str) -> None:
-        super().__init__(adb_arguments)
+    def __init__(self, adb_arguments: List[str], adb_encoding: str, skip_permission_denied: bool) -> None:
+        super().__init__(adb_arguments, skip_permission_denied)
         self.adb_encoding = adb_encoding
         self.proc_adb_shell = subprocess.Popen(
             self.adb_arguments + ["shell"],
@@ -117,9 +119,15 @@ class AndroidFileSystem(FileSystem):
     def ls_to_stat(self, line: str) -> Tuple[str | None, os.stat_result]:
         if self.RE_NO_SUCH_FILE.fullmatch(line):
             raise FileNotFoundError(f'On Android: "{line}"')
-        elif self.RE_LS_NOT_A_DIRECTORY.fullmatch(line):
+
+        if self.RE_LS_NOT_A_DIRECTORY.fullmatch(line):
             raise NotADirectoryError(f'On Android: "{line}"')
-        elif match := self.RE_LS_TO_STAT.fullmatch(line):
+
+        permission_denied = self.RE_PERMISSION_DENIED.fullmatch(line)
+        if permission_denied:
+            raise PermissionError(errno.EACCES, f'On Android: "{line}"', permission_denied.group(1))
+
+        if match := self.RE_LS_TO_STAT.fullmatch(line):
             match_groupdict = match.groupdict()
             st_mode = stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH  # 755
             if match_groupdict['S_IFREG']:

--- a/src/BetterADBSync/FileSystems/Base.py
+++ b/src/BetterADBSync/FileSystems/Base.py
@@ -8,8 +8,10 @@ from ..SAOLogging import perror
 
 
 class FileSystem:
-    def __init__(self, adb_arguments: List[str]) -> None:
+    def __init__(self, adb_arguments: List[str], skip_permission_denied: bool) -> None:
         self.adb_arguments = adb_arguments
+        self.skip_permission_denied = skip_permission_denied
+        self.permission_denied_skipped = []
 
     def _get_files_tree(self, tree_path: str, tree_path_stat: os.stat_result, follow_links: bool = False):
         # the reason to have two functions instead of one purely recursive one is to use self.lstat_in_dir ie ls
@@ -28,14 +30,22 @@ class FileSystem:
             return self._get_files_tree(tree_path_realpath, tree_path_stat_realpath, follow_links = follow_links)
         elif stat.S_ISDIR(tree_path_stat.st_mode):
             tree = {".": (60 * (int(tree_path_stat.st_atime) // 60), 60 * (int(tree_path_stat.st_mtime) // 60))}
-            for filename, stat_object_child, in self.lstat_in_dir(tree_path):
-                if filename in [".", ".."]:
-                    continue
-                tree[filename] = self._get_files_tree(
-                    self.join(tree_path, filename),
-                    stat_object_child,
-                    follow_links = follow_links)
-            return tree
+            try:
+                for filename, stat_object_child, in self.lstat_in_dir(tree_path):
+                    if filename in [".", ".."]:
+                        continue
+                    tree[filename] = self._get_files_tree(
+                        self.join(tree_path, filename),
+                        stat_object_child,
+                        follow_links = follow_links)
+                return tree
+            except PermissionError as e:
+                if self.skip_permission_denied:
+                    self.permission_denied_skipped.append(e.filename)
+                    logging.warning(f"Skipping sync of directory {e.filename} - access denied")
+                    return None
+                else:
+                    raise e
         elif stat.S_ISREG(tree_path_stat.st_mode):
             return (60 * (int(tree_path_stat.st_atime) // 60), 60 * (int(tree_path_stat.st_mtime) // 60)) # minute resolution
         else:

--- a/src/BetterADBSync/__init__.py
+++ b/src/BetterADBSync/__init__.py
@@ -352,8 +352,8 @@ def main():
         adb_arguments.append(f"-{option}")
         adb_arguments.append(value)
 
-    fs_android = AndroidFileSystem(adb_arguments, args.adb_encoding)
-    fs_local = LocalFileSystem(adb_arguments)
+    fs_android = AndroidFileSystem(adb_arguments, args.adb_encoding, args.skip_permission_denied)
+    fs_local = LocalFileSystem(adb_arguments, args.skip_permission_denied)
 
     try:
         fs_android.test_connection()
@@ -458,6 +458,11 @@ def main():
         log_tree(path_destination, tree_excluded_destination, log_leaves_types = False)
     logging.info("")
 
+    if len(fs_source.permission_denied_skipped) > 0:
+        logging.warning("Source elements skipped because of permission denied error:")
+        for filename in fs_source.permission_denied_skipped:
+            logging.warning(f"    {filename}")
+        logging.info("")
 
     tree_unaccounted_destination_non_excluded = None
     if tree_unaccounted_destination is not None:

--- a/src/BetterADBSync/argparsing.py
+++ b/src/BetterADBSync/argparsing.py
@@ -18,6 +18,7 @@ class Args:
     force: bool
     show_progress: bool
     adb_encoding: str
+    skip_permission_denied: bool
 
     adb_bin: str
     adb_flags: List[str]
@@ -134,6 +135,12 @@ def get_cli_args(docstring: str, version: str) -> Args:
         default = []
     )
 
+    parser.add_argument("--skip-permission-denied",
+        help = "If folders on Android are not accessible because of folder permission ignore this and continue",
+        action = "store_true",
+        dest = "skip_permission_denied"
+    )
+
     parser_direction = parser.add_subparsers(title = "direction",
         dest = "direction",
         required = True
@@ -194,6 +201,7 @@ def get_cli_args(docstring: str, version: str) -> Args:
         args.force,
         args.show_progress,
         args.adb_encoding,
+        args.skip_permission_denied,
 
         args.adb_bin,
         args.adb_flags,


### PR DESCRIPTION
If certain paths e.g. on Android side are not accessible adbsync stops with an error. If the command-line option --skip-permission-denied is used such errors are ignored.